### PR TITLE
Fixed selectors

### DIFF
--- a/src/TssLexer.js
+++ b/src/TssLexer.js
@@ -45,7 +45,7 @@ TssLexer.prototype.lex = function (tssString) {
         return state.continuation(rest);
     }
 
-    INIT(/\"(#|\.)?[a-zA-Z0-9]+(\[[a-zA-Z=\s]+\])*\"/)(function (match, rest, state) {
+    INIT(/\"(#|\.)?[a-zA-Z0-9\-]+(\[[a-zA-Z0-9=\s\.]+\])*\"/)(function (match, rest, state) {
         if (tokens.length && tokens[tokens.length - 1].constructor.name === 'PropertyDefinition') {
             return addStyleValue(match, rest, state);
         }

--- a/tests/tss2stss-test-app/tss-fixtures/about.tss
+++ b/tests/tss2stss-test-app/tss-fixtures/about.tss
@@ -47,4 +47,13 @@
         fontStyle: 'normal',
         fontWeight: 'bold'
     }
+},
+".this-is-a-test": {
+    color: "blue"
+},
+".this-is-a-test[formFactor=tablet]": {
+    color: "red"
+},
+".this-is-a-test[platform=ios if=Alloy.Globals.isIos7Plus]": {
+    color: "red"
 }


### PR DESCRIPTION
This commit allows to compile selectors with dashes and specifiers containing numbers and dots.
Some tests show the benefits.
